### PR TITLE
Adds a download button

### DIFF
--- a/src/Editor.tsx
+++ b/src/Editor.tsx
@@ -1,6 +1,6 @@
-import {Button, Card, Flex, Inline, Spinner, Stack, Text} from '@sanity/ui'
-import {CloseIcon, GenerateIcon} from '@sanity/icons'
-import {DialogLabels, EditorLayout, SanityDocument} from './types'
+import { Button, Card, Flex, Inline, Spinner, Stack, Text } from '@sanity/ui'
+import { CloseIcon, GenerateIcon, DownloadIcon } from '@sanity/icons'
+import { DialogLabels, EditorLayout, SanityDocument } from './types'
 import * as React from 'react'
 
 import EditorField from './EditorField'
@@ -23,9 +23,9 @@ const DEFAULT_DIMENSIONS = {
 }
 
 const Editor: React.FC<EditorProps> = (props) => {
-  const {activeLayout, setActiveLayout, generateImage, disabled, captureRef, data, setData} =
+  const { activeLayout, setActiveLayout, generateImage, downloadImage, disabled, captureRef, data, setData } =
     useEditorLogic(props)
-  const {dialog, onClose, layouts, scheme } = props;
+  const { dialog, onClose, layouts, scheme } = props;
   const LayoutComponent = activeLayout.component as any
   const fields = activeLayout.fields || []
   const width = activeLayout.dimensions?.width || DEFAULT_DIMENSIONS.width
@@ -37,7 +37,7 @@ const Editor: React.FC<EditorProps> = (props) => {
       height="fill"
       sizing="border"
       display="flex"
-      style={{flexDirection: 'column'}}
+      style={{ flexDirection: 'column' }}
     >
       <Card
         scheme={scheme}
@@ -45,18 +45,25 @@ const Editor: React.FC<EditorProps> = (props) => {
         padding={4}
         marginBottom={[4, 0]}
         borderBottom
-        style={{textAlign: 'right'}}
+        style={{ textAlign: 'right' }}
       >
         <Flex justify="space-between" align="center">
           <Inline space={3}>
             <Text size={3} weight="semibold">
               {dialog?.title || 'Create image'}
             </Text>
-            <Button
+            {onClose && (<Button
               icon={disabled ? Spinner : GenerateIcon}
               tone="positive"
               text={dialog?.finishCta || 'Generate'}
               onClick={generateImage}
+              disabled={disabled}
+            />)}
+            <Button
+              icon={disabled ? Spinner : DownloadIcon}
+              tone="default"
+              text={dialog?.finishCta || 'Download'}
+              onClick={downloadImage}
               disabled={disabled}
             />
           </Inline>
@@ -77,7 +84,7 @@ const Editor: React.FC<EditorProps> = (props) => {
         align="flex-start"
         wrap="wrap"
         overflow="auto"
-        style={{width: '100%', height: 'auto', minHeight: '0'}}
+        style={{ width: '100%', height: 'auto', minHeight: '0' }}
         sizing="border"
         padding={3}
       >
@@ -85,7 +92,7 @@ const Editor: React.FC<EditorProps> = (props) => {
           scheme={scheme}
           padding={3}
           marginRight={4}
-          style={{maxWidth: '350px', flex: '1 0 200px'}}
+          style={{ maxWidth: '350px', flex: '1 0 200px' }}
           sizing="border"
         >
           <Stack space={4}>

--- a/src/useEditorLogic.ts
+++ b/src/useEditorLogic.ts
@@ -1,16 +1,17 @@
-import {EditorLayout, LayoutData} from './types'
+import { EditorLayout, LayoutData } from './types'
 import download from 'downloadjs'
-import {toPng} from 'html-to-image'
-import React, {useEffect, useState, useRef} from 'react'
+import { toPng } from 'html-to-image'
+import React, { useEffect, useState, useRef } from 'react'
 
 import defaultLayout from './defaultLayout'
-import {EditorProps} from './Editor'
+import { EditorProps } from './Editor'
 
-function useEditorLogic({document, layouts, onSelect}: EditorProps): {
+function useEditorLogic({ document, layouts, onSelect }: EditorProps): {
   activeLayout: EditorLayout
   setActiveLayout: (newLayout: EditorLayout) => void
   disabled: boolean
   generateImage: (e: React.FormEvent) => void
+  downloadImage: (e: React.FormEvent) => void
   captureRef?: React.RefObject<HTMLDivElement>;
   data: LayoutData
   setData: (newData: LayoutData) => void
@@ -33,7 +34,7 @@ function useEditorLogic({document, layouts, onSelect}: EditorProps): {
       // @ts-ignore
       ? activeLayout.prepare(document)
       : // Studio tools should start with empty data
-        {}
+      {}
   )
 
   useEffect(() => {
@@ -66,9 +67,27 @@ function useEditorLogic({document, layouts, onSelect}: EditorProps): {
             },
           },
         ])
-      } else {
-        download(imgBase64, 'generated.png')
       }
+    } catch (error) {
+      setStatus('error')
+      console.error(error)
+    }
+  }
+
+  async function downloadImage(e: React.FormEvent) {
+    e.preventDefault()
+    if (!captureRef?.current) {
+      return
+    }
+    try {
+      setStatus('loading')
+      const imgBase64 = await toPng(captureRef.current, {
+        quality: 1,
+        pixelRatio: 1,
+      })
+      setStatus('success')
+      download(imgBase64, 'generated.png')
+
     } catch (error) {
       setStatus('error')
       console.error(error)
@@ -80,6 +99,7 @@ function useEditorLogic({document, layouts, onSelect}: EditorProps): {
     setActiveLayout,
     disabled,
     generateImage,
+    downloadImage,
     captureRef,
     data,
     setData,


### PR DESCRIPTION
This PR replaces the single 'generateImage' function with 'generateImage' and 'downloadImage'.

There are times when I'd like to generate an image using fields from a document, but I don't require this to be saved as an asset.

Instead, I've added a 'downloadImage' function that is used in the Studio Tool. But also appears in the asset source component.