### PR TITLE
`document` was missing in layout props, use the useFormValue hook

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -4,6 +4,7 @@ import Editor from './Editor'
 import React, {useCallback} from 'react'
 import isHotkey from 'is-hotkey'
 import defaultLayout from './defaultLayout'
+import { useFormValue } from 'sanity'
 
 interface SelectedAsset {
   [key: string]: any
@@ -28,7 +29,6 @@ type Props = {
    * Exclusive to studio tools.
    */
   tool?: ToolType
-  document?: SanityDocument
   selectedAssets?: SelectedAsset[]
   selectionType: 'single'
   darkMode?: boolean
@@ -46,6 +46,8 @@ const MediaEditor: React.FC<Props> = (props) => {
   }, [])
   useGlobalKeyDown(handleGlobalKeyDown)
 
+  const _document = useFormValue([]) as SanityDocument
+
   let layouts = (typeof tool === 'object' && tool.props?.layouts) || props.layouts
   layouts = layouts?.filter((layout) => layout.prepare && layout.component)
 
@@ -59,7 +61,7 @@ const MediaEditor: React.FC<Props> = (props) => {
     return null
   }
 
-  const document: SanityDocument = props.document || {_id: 'unknown'}
+  const document: SanityDocument = _document || ({_id: 'unknown'} as const)
 
   const editorProps = {
     document,


### PR DESCRIPTION
### **User description**
I'm assuming the Sanity API for media selection changed at some point, but the document was always missing unless I added this.


___

### **PR Type**
Bug fix


___

### **Description**
- Fix missing `document` prop by using `useFormValue` hook

- Remove `document` from component props interface

- Add proper document retrieval from Sanity form context


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Props Interface"] --> B["Remove document prop"]
  C["useFormValue Hook"] --> D["Get document from form context"]
  B --> E["MediaEditor Component"]
  D --> E
  E --> F["Pass document to layouts"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>app.tsx</strong><dd><code>Replace document prop with useFormValue hook</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app.tsx

<li>Import <code>useFormValue</code> hook from Sanity<br> <li> Remove <code>document</code> prop from Props interface<br> <li> Use <code>useFormValue([])</code> to retrieve document from form context<br> <li> Update document assignment logic with fallback


</details>


  </td>
  <td><a href="https://github.com/catherineriver/sanity-plugin-generate-ogimage/pull/10/files#diff-bb830d0e6ecfec0dcd1c77dd21e86fd88d6aac900a9a491d75f3e5e99892e47d">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>